### PR TITLE
Fix `undefined` being passed to PorterStemmer.stem

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -42,6 +42,7 @@ var normalizing = function (sentence) {
 	for(var i in words) {
 		if(isStopWord(words[i])) {
 			words.splice(i, 1);
+			continue;
 		}
 		words[i] = natural.PorterStemmer.stem(words[i]);
 	}


### PR DESCRIPTION
When the last word in a sentence is a stop word , it is removed and then `words[i]` becomes `undefined`. This causes an error when the `undefined` value is passed to the `natural.PorterStemmer.stem` function. For example, the following sentence was causing an error:

    These algorithms make more nuanced decisions than the rules we are all used to.

The change made skips the call to the stemmer completely if the word at index `i` has been removed.